### PR TITLE
Support `Money.t` from `:ex_money` hex lib

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.14.0-otp-25
+erlang 25.3.2

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ Ecto struct can also be used directly as variant
 Factory.insert(MyApp.User)
 ```
 
+### For devs running tests
+
+Need env var, probably like this:
+
+```shell
+export DATABASE_URL=postgres://postgres@localhost/factori_test
+```
+
+
 ## License
 
 `factori` is © 2023 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/simonprev/factori/blob/master/LICENSE.md) file.

--- a/lib/factori/ecto.ex
+++ b/lib/factori/ecto.ex
@@ -49,10 +49,10 @@ defmodule Factori.Ecto do
   def dump_value(value, %{ecto_type: ecto_type_module})
       when is_struct(value) and is_atom(ecto_type_module) do
     with true <- function_exported?(ecto_type_module, :dump, 1),
-        {:ok, value} <- ecto_type_module.dump(value) do
+         {:ok, value} <- ecto_type_module.dump(value) do
       value
-      else
-        _ -> value
+    else
+      _ -> value
     end
   end
 

--- a/lib/factori/ecto.ex
+++ b/lib/factori/ecto.ex
@@ -46,6 +46,16 @@ defmodule Factori.Ecto do
   def dump_value(value, column) when column.type === "varchar", do: to_string(value)
   def dump_value(value, column) when column.type === "_varchar", do: to_string(value)
 
+  def dump_value(value, %{ecto_type: ecto_type_module})
+      when is_struct(value) and is_atom(ecto_type_module) do
+    with true <- function_exported?(ecto_type_module, :dump, 1),
+        {:ok, value} <- ecto_type_module.dump(value) do
+      value
+      else
+        _ -> value
+    end
+  end
+
   def dump_value(value, _), do: value
 
   def load_value(nil, _), do: nil


### PR DESCRIPTION
I needed this to make `ex_money` work with `factori` (fields of type `Money.Ecto.Composite.Type`).

I will write tests, some time in the future.

Also some incidental work in README and tool-versions for asdf users.