### PR TITLE
Fix flakiness when ecto type module not loaded

### DIFF
--- a/lib/factori/ecto.ex
+++ b/lib/factori/ecto.ex
@@ -41,9 +41,8 @@ defmodule Factori.Ecto do
 
   def dump_value(value, %{ecto_type: ecto_type_module})
       when is_atom(ecto_type_module) do
-    Code.ensure_loaded!(ecto_type_module)
-
-    with true <- function_exported?(ecto_type_module, :dump, 1),
+    with {:module, ecto_type_module} <- Code.ensure_loaded(ecto_type_module),
+         true <- function_exported?(ecto_type_module, :dump, 1),
          {:ok, value} <- Ecto.Type.dump(ecto_type_module, value) do
       value
     else

--- a/lib/factori/ecto.ex
+++ b/lib/factori/ecto.ex
@@ -41,7 +41,7 @@ defmodule Factori.Ecto do
 
   def dump_value(value, %{ecto_type: ecto_type_module})
       when is_atom(ecto_type_module) do
-    Code.ensure_loaded(ecto_type_module)
+    Code.ensure_loaded!(ecto_type_module)
 
     with true <- function_exported?(ecto_type_module, :dump, 1),
          {:ok, value} <- Ecto.Type.dump(ecto_type_module, value) do

--- a/lib/factori/ecto.ex
+++ b/lib/factori/ecto.ex
@@ -41,6 +41,8 @@ defmodule Factori.Ecto do
 
   def dump_value(value, %{ecto_type: ecto_type_module})
       when is_atom(ecto_type_module) do
+    Code.ensure_loaded(ecto_type_module)
+
     with true <- function_exported?(ecto_type_module, :dump, 1),
          {:ok, value} <- Ecto.Type.dump(ecto_type_module, value) do
       value


### PR DESCRIPTION
Sometimes an underlying ecto type module, e.g. `Money.Ecto.Composite.Type` is not loaded and this will cause the `&dump/1` function to not be found.